### PR TITLE
Add a way to setfenv() arbitrary Lua code commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ end)
 
 The stream argument is a function that allows the client to stream data instead of returning everything in one go. Call the function with the data to send to the client. Start by sending a header indicating a chunked transfer encoding.
 
+#### Set global environment
+By default, Lua commands will run with the global table as the [environment](https://www.lua.org/manual/5.1/manual.html#2.9).
+If you need to expand or confine this environment, you can provide a custom table:
+
+```
+local console = require("defcon.console")
+local my_env = { foo = "bar" }
+setmetatable(my_env, { __index = _G })
+console.set_environment(my_env) -- foo will now be available to Lua commands and inspect
+```
+
 ## Download files
 The web server also allows you to download files available to your game. If you make an HTTP GET or open your browser to the following URL the specified file will be returned:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can extend the console with commands of your own.
 #### Commands from module functions
 You can register whole modules and have all functions mapped as commands:
 
-```
+```lua
 local foobar_module = require("foobar_module")
 local console = require("defcon.console")
 console.register_module(foobar_module)
@@ -55,7 +55,7 @@ console.register_module(foobar_module)
 #### Custom commands
 You can also add custom commands:
 
-```
+```lua
 local console = require("defcon.console")
 console.register_command("mycommand", function(args, stream)
 	-- execute command here
@@ -69,7 +69,7 @@ The stream argument is a function that allows the client to stream data instead 
 By default, Lua commands will run with the global table as the [environment](https://www.lua.org/manual/5.1/manual.html#2.9).
 If you need to expand or confine this environment, you can provide a custom table:
 
-```
+```lua
 local console = require("defcon.console")
 local my_env = { foo = "bar" }
 setmetatable(my_env, { __index = _G })
@@ -86,7 +86,7 @@ localhost:8098/download/path/to/myfile
 ## Custom web server routes
 It's possible to add custom web server routes to serve specific content over HTTP:
 
-```
+```lua
 local console = require("defcon.console")
 console.server.router.get("^/greet/(.*)$", function(matches)
 	local path = matches[1]

--- a/defcon/console.lua
+++ b/defcon/console.lua
@@ -213,7 +213,7 @@ function M.start(port)
 		end
 
 		local name = args[1]
-		local search = { modules, custom_env or _G, package.loaded, { ["_G"] = _G }}
+		local search = { modules, custom_env or _G, package.loaded }
 		for _,t in ipairs(search) do
 			local found = find_in_table(t, name)
 			if found then

--- a/defcon/console.lua
+++ b/defcon/console.lua
@@ -16,6 +16,8 @@ local commands = {}
 
 local modules = {}
 
+local custom_env
+
 local function handle_arg(arg)
 	local ok, num = pcall(tonumber, arg)
 	--return ok and num or arg:gsub("\"", "")
@@ -58,6 +60,9 @@ local function handle_command(command_string, stream)
 			local fn = loadstring("return " .. command_string) or loadstring(command_string)
 			if not fn then
 				return "Error: Unable to run " .. command_string
+			end
+			if custom_env then
+				setfenv(fn, custom_env)
 			end
 			result = { fn() }
 		end)
@@ -208,7 +213,7 @@ function M.start(port)
 		end
 
 		local name = args[1]
-		local search = { modules, _G, package.loaded, { ["_G"] = _G }}
+		local search = { modules, custom_env or _G, package.loaded, { ["_G"] = _G }}
 		for _,t in ipairs(search) do
 			local found = find_in_table(t, name)
 			if found then
@@ -326,6 +331,12 @@ function M.register_module(module, name)
 		end
 		return s
 	end)
+end
+
+--- Set the global environment table used for commands ran as Lua code and inspect.
+-- @param env The table to set as environment when running Lua commands.
+function M.set_environment(env)
+	custom_env = env
 end
 
 return M


### PR DESCRIPTION
This is useful, for example, to add extra "globals" available to the console, but not pollute the actual global namespace.