### PR TITLE
console.register_module to support adding descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ local console = require("defcon.console")
 console.register_module(foobar_module)
 ```
 
+You can add descriptions to your functions within your module by adding a variable with a `_desc` suffix.
+
+```lua
+
+local M = {}
+
+M.foo_desc = "Lorem ipsum dolor sit amet"
+
+function M.foo()
+end
+
+return M
+
+```
+
 #### Custom commands
 You can also add custom commands:
 

--- a/defcon/console.lua
+++ b/defcon/console.lua
@@ -323,7 +323,8 @@ function M.register_module(module, name)
 	modules[name] = module
 	for k,v in pairs(module) do
 		if type(v) == "function" then
-			M.register_command(name .. "." .. k, "", function(args, fn)
+			local description = module[k .. "_desc"] or ""
+			M.register_command(name .. "." .. k, description, function(args, fn)
 				return { v(unpack(args)) }
 			end)
 		end

--- a/example/example.gui_script
+++ b/example/example.gui_script
@@ -1,4 +1,5 @@
 local console = require "defcon.console"
+local example_module = require "example.example_module"
 
 local function get_ip()
 	for i, a in ipairs(sys.get_ifaddrs()) do
@@ -18,6 +19,8 @@ function init(self)
 
 	console.register_module(math, "math")
 	
+	console.register_module(example_module, "example")
+
 	console.server.router.get("^/imgur/(.*)$", function(matches)
 		local path = matches[1]
 		local co = coroutine.running()

--- a/example/example_module.lua
+++ b/example/example_module.lua
@@ -1,0 +1,16 @@
+local M  = {}
+
+
+M.foo_desc = "Lorem ipsum dolor sit amet"
+
+function M.foo()
+end
+
+
+M.bar = "Consectetur adipiscing elit"
+
+function M.bar()
+end
+
+
+return M


### PR DESCRIPTION
Adds the ability to pass in an optional table with descriptions for a module. The description table should have the same name as the exposed functions within the module.

Probably good praxis to keep the description with you debug module.

The module you register would then be
```lua
local M = {}

M.descriptions = {
    foo = "Lorem ipsum dolor sit amet"
}

function M.foo()
end

return M
```

You register it with 
```lua
console.register_module(example_module, "example", example_module.descriptions)
```
