### PR TITLE
Display the commands from the `commands` command sorted.

### DIFF
--- a/defcon/console.lua
+++ b/defcon/console.lua
@@ -187,7 +187,13 @@ function M.start(port)
 
 	M.register_command("commands", "Show all commands", function()
 		local s = ""
-		for command,command_data in pairs(commands) do
+		local names = {}
+		for command, command_data in pairs(commands) do
+			table.insert(names, command)
+		end
+		table.sort(names)
+
+		for _,command in ipairs(names) do
 			if command:match(".*%..*") ~= command then
 				s = s .. " - " .. command .. "\n"
 			end


### PR DESCRIPTION
<sub>_that's the clearest title I could come up with..._</sub>

The command to show all commands now displays the commands sorted. Might be alone in it, but sometimes I would be confused that a command was missing, but it wasn't missing it was just in a different position in the list.