### PR TITLE
Reduced border size

### DIFF
--- a/defcon/html/console_html.lua
+++ b/defcon/html/console_html.lua
@@ -99,6 +99,10 @@ return [[
 			flex-flow: column;
 			height: 100%;
 		}
+		body {
+			background-color: #2D2F31;
+			padding: 2px;
+		}
 		#log {
 			font-family: 'Lucida Console', Monaco, monospace;
 			font-size: 20;
@@ -126,7 +130,7 @@ return [[
 		}
 	</style>
 </head>
-<body bgcolor="#2D2F31" style="padding: 20px" onload="document.getElementById('command').focus()">
+<body onload="document.getElementById('command').focus()">
 	<div class="box">
 		<textarea onkeydown="handlekeydown(event)" id="log" readonly></textarea>
 		<input type="text" id="command" onkeydown="handlekeydown(event)" placeholder="&gt;"/>


### PR DESCRIPTION
I always found the big border a bit ugly and taking too much space.

# Before
![{595D0EBA-54FF-4020-B3B5-F02749049D4D}](https://github.com/user-attachments/assets/f0cb9dd8-d737-4614-a38e-a6ad5ffadeeb)


# After
![image](https://github.com/user-attachments/assets/0505f990-1f82-4d19-9849-576d5c89c5aa)


___
###  Alternative
I also played around with having the input a different color than the output. This of course deviates from the "console" look, but I think it's easier to understand at a glance. 
![{051FAAEF-F57B-47F0-A359-D0D166503D43}](https://github.com/user-attachments/assets/585b4062-e8f7-4bb3-b409-5bb4ef88abc3)

Let me know if you would like the alternative and I will change the MR. Else feel free to close the MR if you prefer the bigger border.