### PR TITLE
Cycle through suggestions with tab

### DIFF
--- a/defcon/console.lua
+++ b/defcon/console.lua
@@ -152,7 +152,8 @@ function M.start(port)
 
 	-- serve the console
 	M.server.router.get("^/$", function()
-		return M.server.html(console_html)
+		
+		return M.server.html(console_html.html(commands))
 	end)
 
 	-- download a file


### PR DESCRIPTION
<tab> now finishes and cycles through commands.

It cycles and suggests up to the next `.`

If you are writing `comm` and press tab it will expand it to `commands` if you tab again (exceed the length of the suggestion list) it will go back to `comm`. 

By not writing anything after the dot we can cycle through the commands within the module. 
https://github.com/user-attachments/assets/8dd2537b-1f36-458d-9ec6-ccc49ff35b3a

