### PR TITLE
allow dot in command name

### DIFF
--- a/defcon/console.lua
+++ b/defcon/console.lua
@@ -195,7 +195,8 @@ function M.start(port)
 		table.sort(names)
 
 		for _,command in ipairs(names) do
-			if command:match(".*%..*") ~= command then
+			local command_data = commands[command]
+			if command_data.source == "command" then
 				s = s .. " - " .. command .. "\n"
 			end
 		end
@@ -300,7 +301,7 @@ function M.register_command(command, description, fn)
 	assert(command, "You must provide a command")
 	assert(description, "You must provide a command description")
 	assert(fn, "You must provide a command function")
-	commands[command] = { fn = fn, description = description }
+	commands[command] = { fn = fn, description = description, source = "command" }
 end
 
 
@@ -331,9 +332,10 @@ function M.register_module(module, name)
 	for k,v in pairs(module) do
 		if type(v) == "function" then
 			local description = module[k .. "_desc"] or ""
-			M.register_command(name .. "." .. k, description, function(args, fn)
+			local fn_ = function(args, fn)
 				return { v(unpack(args)) }
-			end)
+			end
+			commands[name .. "." .. k] = {fn = fn_, description = description, source=name}
 		end
 	end
 


### PR DESCRIPTION
This is a _bit_ opinionated, but personally I never liked that any command with `.` in them were hidden.

This adds a `source` to the command and instead of hiding commands that match a pattern we instead now only show the command if it is are registered as a command (have "command" as source).

### Previous behavior

If I added two commands like this
```lua
console.register_command("say.hello", "Say Hello", function() return "Hello" end)
console.register_command("say.world", "Say world", function() return "world!" end)
```

These commands would not be visible, but they would still work. So writing `say.hello` would still print "Hello", likewise `help say.hello` would also work. But when doing `commands` these commands would not be displayed in the list.

The change is that these commands now shows when printing all available commands with `commands`.